### PR TITLE
Exclude loop variables from callable-token parsing

### DIFF
--- a/releasenotes/notes/fix-callable-loop-variable-11d0143b19364d2c.yaml
+++ b/releasenotes/notes/fix-callable-loop-variable-11d0143b19364d2c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Loop variables will no longer be lexed as callable tokens.

--- a/src/openqasm_pygments/qasm3.py
+++ b/src/openqasm_pygments/qasm3.py
@@ -168,6 +168,7 @@ class OpenQASM3Lexer(RegexLexer):
             # functions) as callables.  Since we use the same highlighting for gates and functions,
             # it doesn't matter that we'll tokenise (e.g.) the identifier in `rz(...)` with the
             # function rule not the gate one.
+            (_lexeme.IDENTIFIER + r"(?=[ \r\n\t]+in\b)", token.Name),  # Skip the loop variable.
             (_lexeme.IDENTIFIER + rf"(?=[ \r\n\t]+{_lexeme.IDENTIFIER})", token.Name.Function),
             (_lexeme.IDENTIFIER + r"(?=[ \r\n\t]*\()", token.Name.Function),
             # Identifiers.

--- a/tests/examples/qasm3/adder.qasm.output
+++ b/tests/examples/qasm3/adder.qasm.output
@@ -200,7 +200,7 @@
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -279,7 +279,7 @@
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -340,7 +340,7 @@
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace

--- a/tests/examples/qasm3/ipe.qasm.output
+++ b/tests/examples/qasm3/ipe.qasm.output
@@ -115,7 +115,7 @@
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace

--- a/tests/examples/qasm3/msd.qasm.output
+++ b/tests/examples/qasm3/msd.qasm.output
@@ -1133,7 +1133,7 @@
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace

--- a/tests/examples/qasm3/scqec.qasm.output
+++ b/tests/examples/qasm3/scqec.qasm.output
@@ -275,7 +275,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'row'               Token.Name.Function
+'row'               Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -297,7 +297,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'col'               Token.Name.Function
+'col'               Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -381,7 +381,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -488,7 +488,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'row'               Token.Name.Function
+'row'               Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -512,7 +512,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'col'               Token.Name.Function
+'col'               Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -663,7 +663,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -757,7 +757,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -873,7 +873,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'shot'              Token.Name.Function
+'shot'              Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -927,7 +927,7 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace

--- a/tests/examples/qasm3/t1.qasm.output
+++ b/tests/examples/qasm3/t1.qasm.output
@@ -151,7 +151,7 @@
 '\n\n'              Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
-'p'                 Token.Name.Function
+'p'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace

--- a/tests/examples/qasm3/varteleport.qasm.output
+++ b/tests/examples/qasm3/varteleport.qasm.output
@@ -149,7 +149,7 @@
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace

--- a/tests/examples/qasm3/vqe.qasm.output
+++ b/tests/examples/qasm3/vqe.qasm.output
@@ -196,7 +196,7 @@
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -345,7 +345,7 @@
 'prec'              Token.Name
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -519,7 +519,7 @@
 'prec'              Token.Name
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'l'                 Token.Name.Function
+'l'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -543,7 +543,7 @@
 'prec'              Token.Name
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -670,7 +670,7 @@
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
-'i'                 Token.Name.Function
+'i'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace
@@ -785,7 +785,7 @@
 'prec'              Token.Name
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
-'t'                 Token.Name.Function
+'t'                 Token.Name
 ' '                 Token.Text.Whitespace
 'in'                Token.Keyword
 ' '                 Token.Text.Whitespace

--- a/tests/test_qasm3_lexer.py
+++ b/tests/test_qasm3_lexer.py
@@ -18,6 +18,56 @@ class DummyLexer(RegexLexer):
     tokens = {"root": [("^.+$", token.Text)]}
 
 
+def test_function_lookahead(lexer_qasm3):
+    text = """
+gate f q {}
+def f() {}
+f a;
+f(1);
+f(1) a;
+"""
+    assert _remove_whitespace(lexer_qasm3.get_tokens(text)) == [
+        (token.Keyword.Declaration, "gate"),
+        (token.Name.Function, "f"),
+        (token.Name, "q"),
+        (token.Punctuation, "{"),
+        (token.Punctuation, "}"),
+        (token.Keyword.Declaration, "def"),
+        (token.Name.Function, "f"),
+        (token.Punctuation, "("),
+        (token.Punctuation, ")"),
+        (token.Punctuation, "{"),
+        (token.Punctuation, "}"),
+        (token.Name.Function, "f"),
+        (token.Name, "a"),
+        (token.Punctuation, ";"),
+        (token.Name.Function, "f"),
+        (token.Punctuation, "("),
+        (token.Number, "1"),
+        (token.Punctuation, ")"),
+        (token.Punctuation, ";"),
+        (token.Name.Function, "f"),
+        (token.Punctuation, "("),
+        (token.Number, "1"),
+        (token.Punctuation, ")"),
+        (token.Name, "a"),
+        (token.Punctuation, ";"),
+    ]
+
+
+def test_for_loop_variable_not_callable(lexer_qasm3):
+    text = "for uint i in a {}"
+    assert _remove_whitespace(lexer_qasm3.get_tokens(text)) == [
+        (token.Keyword, "for"),
+        (token.Keyword.Type, "uint"),
+        (token.Name, "i"),
+        (token.Keyword, "in"),
+        (token.Name, "a"),
+        (token.Punctuation, "{"),
+        (token.Punctuation, "}"),
+    ]
+
+
 class TestPulseLexerDelegation:
     def test_inferred_known_alias(self, lexer_qasm3):
         # This uses a very (!) non-standard pulse-grammar lexer to test delegation


### PR DESCRIPTION
The (slightly hacky) lookahead to determine if a token is callable
didn't account for locations where identifier can be succeeded by
another object that _looks_ like an identifier, if it's actually a
keyword.  In this case, the for loop variable is followed by 'in'.