### PR TITLE
Lex annotation namespaces

### DIFF
--- a/releasenotes/notes/lex-namespace-annotations-34e856acd9837226.yaml
+++ b/releasenotes/notes/lex-namespace-annotations-34e856acd9837226.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Annotation keywords will now be correctly lexed as a single ``Token.Name.Decorator`` token.

--- a/src/openqasm_pygments/qasm3.py
+++ b/src/openqasm_pygments/qasm3.py
@@ -75,7 +75,7 @@ class OpenQASM3Lexer(RegexLexer):
     tokens = {
         "root": [
             (r"^[ \t]*#?pragma", token.Comment.Preproc, "pragma"),
-            (r"^[ \t]*@\w+", token.Name.Decorator, "annotation"),
+            (r"^[ \t]*@\w+(\.\w+)*", token.Name.Decorator, "annotation"),
             (r"[ \r\n\t]+", token.Whitespace),
             (r"\bOPENQASM\b", token.Comment.Preproc, "version"),
             (r"//.*$", token.Comment.Single),

--- a/tests/test_qasm3_lexer.py
+++ b/tests/test_qasm3_lexer.py
@@ -81,7 +81,7 @@ qubit q;
         (token.Name.Decorator, "@namespace1.namespace2.annotation"),
         (token.Keyword.Type, "qubit"),
         (token.Name, "q"),
-        (token.Punctuation, ";")
+        (token.Punctuation, ";"),
     ]
 
 

--- a/tests/test_qasm3_lexer.py
+++ b/tests/test_qasm3_lexer.py
@@ -68,6 +68,23 @@ def test_for_loop_variable_not_callable(lexer_qasm3):
     ]
 
 
+def test_annotation_namespace(lexer_qasm3):
+    text = """\
+@annotation
+@namespace.annotation
+@namespace1.namespace2.annotation
+qubit q;
+"""
+    assert _remove_whitespace(lexer_qasm3.get_tokens(text)) == [
+        (token.Name.Decorator, "@annotation"),
+        (token.Name.Decorator, "@namespace.annotation"),
+        (token.Name.Decorator, "@namespace1.namespace2.annotation"),
+        (token.Keyword.Type, "qubit"),
+        (token.Name, "q"),
+        (token.Punctuation, ";")
+    ]
+
+
 class TestPulseLexerDelegation:
     def test_inferred_known_alias(self, lexer_qasm3):
         # This uses a very (!) non-standard pulse-grammar lexer to test delegation


### PR DESCRIPTION
According to the OpenQASM 3 grammar the `annotation` keyword does support namespaces by chaining `Identifier`s using the `.` symbol.
https://github.com/openqasm/openqasm/blob/12de90c301500bd01b9f65bdcbbf4a5ec5c2fec9/source/grammar/qasm3Lexer.g4#L42

But the regex in the pygments lexer does not allow this.
https://github.com/openqasm/openqasm-pygments/blob/734ccf7a46f10e37406f1103368c552debdb0fb6/src/openqasm_pygments/qasm3.py#L78

---

Fixes #2