### PR TITLE
Update out-of-date tool versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
     name: Publish package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
 
       - name: Install build dependencies
         run: pip install -U twine build
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: python -mbuild --wheel --sdist .
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             ./dist/*.whl
@@ -35,7 +35,7 @@ jobs:
         run: twine upload dist/*.whl dist/*.tar.gz
 
       - name: Publish to GitHub
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           prerelease: false
@@ -49,11 +49,11 @@ jobs:
     name: Publish documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: python -m pip install --upgrade pip tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,21 +11,11 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      # Set up all supported Python versions for tox.
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.8'
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.9'
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.10'
+          python-version: '>=3.9'
 
       - name: Update pip
         run: python -mpip install --upgrade pip
@@ -38,10 +28,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Update pip
         run: python -mpip install --upgrade pip
       - name: Install tox
@@ -53,10 +43,10 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Update pip
         run: python -mpip install --upgrade pip
       - name: Install tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ["py37", "py38", "py39", "py310"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 [tool.pylint.main]
 # Minimum supported Python version.
-py-version = "3.7"
+py-version = "3.9"
 [tool.pylint.basic]
 # Naming convention for objects that do not require docstrings.
 no-docstring-rgx = "^_"

--- a/releasenotes/notes/drop-py38-752c601406733265.yaml
+++ b/releasenotes/notes/drop-py38-752c601406733265.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The officially supported Python versions are now 3.9 onwards.  Any remaining support for the
+    end-of-life Pythons 3.7 and 3.8 is coincidental and may break without warning.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ package_dir =
     = src
 install_requires =
     Pygments ~= 2.0
-    importlib_metadata; python_version < "3.8"
 
 [options.packages.find]
 where = src/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py39, py310, py311, py312, py313
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
This drops official support for Pythons 3.7 and 3.8 which are long since end-of-life.  The various versions of GitHub Actions used in the CI pipelines are brought (mostly) up-to-date.