### PR TITLE
Fix indented annotations and pragmas

### DIFF
--- a/releasenotes/notes/indented-annotations-661bf85c6702a134.yaml
+++ b/releasenotes/notes/indented-annotations-661bf85c6702a134.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Annotations and pragmas that are indented will now tokenise correctly, without including the
+    leading whitespace of the line.
+fixes:
+  - |
+    The free-form payloads of annotations and pragmas will now no longer include preceding spaces
+    that only separate the payload from the annotation/pragma keywords.
+  - |
+    Indented annotations and pragmas will now more reliably tokenise correctly; previously, they
+    were highly sensitive to whitespace on the preceding lines.
+other:
+  - |
+    Whitespace tokens now split after newlines, except if the following character is also a newline
+    character.  This is so that newline-sensitive tokenisation like annotations and pragmas can
+    match correctly.

--- a/scripts/bless_examples.py
+++ b/scripts/bless_examples.py
@@ -1,0 +1,34 @@
+# Rewrite the output files in the `tests/examples` with the new output of the lexer.  The resulting
+# output should be checked that it is actually correct, since this blesses things for the new test
+# suite.
+
+import pathlib
+import openqasm_pygments
+
+
+def rewrite(fname, lexer):
+    with open(fname, "r", encoding="utf-8") as fptr:
+        content = fptr.read().strip()
+    return "\n".join(
+        f"{repr(token):<19s} {ttype}" for ttype, token in lexer.get_tokens(content)
+    )
+
+
+if __name__ == "__main__":
+    repo_root = pathlib.Path(__file__).parents[1]
+    examples_dir = repo_root / "tests" / "examples"
+    configs = [
+        (examples_dir / "qasm2", (".qasm", ".inc"), openqasm_pygments.OpenQASM2Lexer()),
+        (examples_dir / "qasm3", (".qasm",), openqasm_pygments.OpenQASM3Lexer()),
+        (
+            examples_dir / "openqasm",
+            (".openpulse",),
+            openqasm_pygments.OpenPulseLexer(),
+        ),
+    ]
+    for dir_, suffixes, lexer in configs:
+        for suffix in suffixes:
+            for file in dir_.glob(f"**/*{suffix}"):
+                new_tokens = rewrite(file, lexer)
+                with open(str(file) + ".output", "w", encoding="utf-8") as fptr:
+                    print(new_tokens, file=fptr)

--- a/src/openqasm_pygments/qasm3.py
+++ b/src/openqasm_pygments/qasm3.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Union, Mapping, Optional, Sequence, Tuple
 
 from pygments import token
-from pygments.lexer import Lexer, RegexLexer, words, include
+from pygments.lexer import Lexer, RegexLexer, words, include, bygroups
 from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 
@@ -74,9 +74,19 @@ class OpenQASM3Lexer(RegexLexer):
 
     tokens = {
         "root": [
-            (r"^[ \t]*#?pragma", token.Comment.Preproc, "pragma"),
-            (r"^[ \t]*@\w+(\.\w+)*", token.Name.Decorator, "annotation"),
-            (r"[ \r\n\t]+", token.Whitespace),
+            (
+                r"^([ \t]*)(#?pragma)([ \t]*)",
+                bygroups(token.Whitespace, token.Comment.Preproc, token.Whitespace),
+                "annotation",
+            ),
+            (
+                r"^([ \t]*)(@\w+(\.\w+)*)([ \t]*)",
+                bygroups(token.Whitespace, token.Name.Decorator, token.Whitespace),
+                "annotation",
+            ),
+            # Newline terminates the tokenisation so that new-line sensitive matches like annotations
+            # get to see the start-of-line character in their match.
+            (r"([ \r\t]+\n*)|(\n+)", token.Whitespace),
             (r"\bOPENQASM\b", token.Comment.Preproc, "version"),
             (r"//.*$", token.Comment.Single),
             (r"/\*", token.Comment.Multiline, "comment"),

--- a/tests/examples/qasm3/adder.qasm.output
+++ b/tests/examples/qasm3/adder.qasm.output
@@ -31,7 +31,8 @@
 'c'                 Token.Name
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'c'                 Token.Name
@@ -39,7 +40,8 @@
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'c'                 Token.Name
@@ -47,7 +49,8 @@
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'ccx'               Token.Name.Function
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
@@ -74,7 +77,8 @@
 'c'                 Token.Name
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'ccx'               Token.Name.Function
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
@@ -85,7 +89,8 @@
 ' '                 Token.Text.Whitespace
 'c'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'c'                 Token.Name
@@ -93,7 +98,8 @@
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
@@ -212,7 +218,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'bool'              Token.Keyword.Type
@@ -231,7 +238,8 @@
 'i'                 Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'bool'              Token.Keyword.Type

--- a/tests/examples/qasm3/arrays.qasm.output
+++ b/tests/examples/qasm3/arrays.qasm.output
@@ -100,7 +100,8 @@
 '='                 Token.Operator
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '{'                 Token.Punctuation
 '0.5'               Token.Literal.Number.Float
 ','                 Token.Punctuation
@@ -108,7 +109,8 @@
 '0.5'               Token.Literal.Number.Float
 '}'                 Token.Punctuation
 ','                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '{'                 Token.Punctuation
 '1.0'               Token.Literal.Number.Float
 ','                 Token.Punctuation
@@ -116,7 +118,8 @@
 '2.0'               Token.Literal.Number.Float
 '}'                 Token.Punctuation
 ','                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '{'                 Token.Punctuation
 '-'                 Token.Operator
 '0.4'               Token.Literal.Number.Float
@@ -125,7 +128,8 @@
 '0.7'               Token.Literal.Number.Float
 '}'                 Token.Punctuation
 ','                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '{'                 Token.Punctuation
 '1.3'               Token.Literal.Number.Float
 ','                 Token.Punctuation
@@ -505,9 +509,11 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '// Within this block, ``in_array`` can be read from, but not written to,' Token.Comment.Single
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '// whereas ``out_array`` can be both read from and written to.' Token.Comment.Single
 '\n'                Token.Text.Whitespace
 '}'                 Token.Punctuation
@@ -543,7 +549,8 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 '['                 Token.Punctuation
 '32'                Token.Literal.Number
@@ -561,7 +568,8 @@
 '0'                 Token.Literal.Number
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 '['                 Token.Punctuation
 '32'                Token.Literal.Number
@@ -579,7 +587,8 @@
 '1'                 Token.Literal.Number
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 '['                 Token.Punctuation
 '32'                Token.Literal.Number

--- a/tests/examples/qasm3/cphase.qasm.output
+++ b/tests/examples/qasm3/cphase.qasm.output
@@ -11,7 +11,8 @@
 'b'                 Token.Name
 '\n'                Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'U'                 Token.Name.Builtin
 '('                 Token.Punctuation
 '0'                 Token.Literal.Number
@@ -29,7 +30,8 @@
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'CX'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
@@ -37,7 +39,8 @@
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'U'                 Token.Name.Builtin
 '('                 Token.Punctuation
 '0'                 Token.Literal.Number
@@ -56,7 +59,8 @@
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'CX'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
@@ -64,7 +68,8 @@
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'U'                 Token.Name.Builtin
 '('                 Token.Punctuation
 '0'                 Token.Literal.Number

--- a/tests/examples/qasm3/dd.qasm.output
+++ b/tests/examples/qasm3/dd.qasm.output
@@ -120,7 +120,8 @@
 'box'               Token.Keyword
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'delay'             Token.Operator.Word
 '['                 Token.Punctuation
 'start_stretch'     Token.Name
@@ -128,12 +129,14 @@
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'x'                 Token.Name
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'delay'             Token.Operator.Word
 '['                 Token.Punctuation
 'middle_stretch'    Token.Name
@@ -141,12 +144,14 @@
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'y'                 Token.Name
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'delay'             Token.Operator.Word
 '['                 Token.Punctuation
 'middle_stretch'    Token.Name
@@ -154,12 +159,14 @@
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'x'                 Token.Name
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'delay'             Token.Operator.Word
 '['                 Token.Punctuation
 'middle_stretch'    Token.Name
@@ -167,12 +174,14 @@
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'y'                 Token.Name
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'delay'             Token.Operator.Word
 '['                 Token.Punctuation
 'end_stretch'       Token.Name
@@ -180,7 +189,8 @@
 ' '                 Token.Text.Whitespace
 '$0'                Token.Literal
 ';'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name
 ' '                 Token.Text.Whitespace
 '$2'                Token.Literal
@@ -188,7 +198,8 @@
 ' '                 Token.Text.Whitespace
 '$3'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name
 ' '                 Token.Text.Whitespace
 '$1'                Token.Literal
@@ -196,7 +207,8 @@
 ' '                 Token.Text.Whitespace
 '$2'                Token.Literal
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'u'                 Token.Name
 ' '                 Token.Text.Whitespace
 '$3'                Token.Literal

--- a/tests/examples/qasm3/gateteleport.qasm.output
+++ b/tests/examples/qasm3/gateteleport.qasm.output
@@ -58,7 +58,8 @@
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 '['                 Token.Punctuation
 '3'                 Token.Literal.Number
@@ -66,12 +67,14 @@
 ' '                 Token.Text.Whitespace
 'c'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'r'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'measure'           Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'd'                 Token.Name
@@ -80,7 +83,8 @@
 ' '                 Token.Text.Whitespace
 'c'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'r'                 Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -90,7 +94,8 @@
 'c'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'r'                 Token.Name

--- a/tests/examples/qasm3/ipe.qasm.output
+++ b/tests/examples/qasm3/ipe.qasm.output
@@ -133,17 +133,20 @@
 '{'                 Token.Punctuation
 '  '                Token.Text.Whitespace
 '// implicitly cast val to int' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'ctrl'              Token.Name.Builtin
 ' '                 Token.Text.Whitespace
 '@'                 Token.Operator
@@ -165,7 +168,8 @@
 ' '                 Token.Text.Whitespace
 'r'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'inv'               Token.Name.Builtin
 ' '                 Token.Text.Whitespace
 '@'                 Token.Operator
@@ -177,12 +181,14 @@
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'measure'           Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
@@ -194,18 +200,22 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// newest measurement outcome is associated to a pi/2 phase shift' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// in the next iteration, so shift all bits of c left' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'c'                 Token.Name
 ' '                 Token.Text.Whitespace
 '<<='               Token.Operator
 ' '                 Token.Text.Whitespace
 '1'                 Token.Literal.Number
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'power'             Token.Name
 ' '                 Token.Text.Whitespace
 '<<='               Token.Operator

--- a/tests/examples/qasm3/msd.qasm.output
+++ b/tests/examples/qasm3/msd.qasm.output
@@ -46,17 +46,20 @@
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 's'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'measure'           Token.Operator.Word
@@ -105,12 +108,14 @@
 'bool'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'temp'              Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 '['                 Token.Punctuation
 '3'                 Token.Literal.Number
@@ -118,9 +123,11 @@
 ' '                 Token.Text.Whitespace
 'checks'            Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Encode two magic states in the [[4,2,2]] code' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -131,7 +138,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -139,7 +147,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -153,7 +162,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -167,7 +177,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -181,7 +192,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -195,9 +207,11 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Body of distillation circuit' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -211,7 +225,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -219,7 +234,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'temp'              Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -232,7 +248,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'temp'              Token.Name
@@ -261,7 +278,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -269,7 +287,8 @@
 '2'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -277,7 +296,8 @@
 '2'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cz'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -291,7 +311,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -305,7 +326,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'temp'              Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -318,7 +340,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'temp'              Token.Name
@@ -344,7 +367,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -352,7 +376,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 's'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -360,7 +385,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -374,7 +400,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'temp'              Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -387,7 +414,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'temp'              Token.Name
@@ -414,7 +442,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cz'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -428,7 +457,8 @@
 '2'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -442,7 +472,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'temp'              Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -455,7 +486,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'temp'              Token.Name
@@ -481,7 +513,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -495,7 +528,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'inv'               Token.Name.Builtin
 ' '                 Token.Text.Whitespace
 '@'                 Token.Operator
@@ -507,7 +541,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cz'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -521,7 +556,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -529,7 +565,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -543,7 +580,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -557,7 +595,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'temp'              Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -570,7 +609,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'temp'              Token.Name
@@ -599,7 +639,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cz'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -613,7 +654,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cz'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -627,7 +669,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -641,7 +684,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'temp'              Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -654,7 +698,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'temp'              Token.Name
@@ -678,7 +723,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -692,7 +738,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'temp'              Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -705,7 +752,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'temp'              Token.Name
@@ -732,7 +780,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cz'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -746,7 +795,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -760,7 +810,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'temp'              Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -773,7 +824,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'temp'              Token.Name
@@ -801,7 +853,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -809,9 +862,11 @@
 '2'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Decode [[4,2,2]] code' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -825,7 +880,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -839,7 +895,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
@@ -853,7 +910,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -867,7 +925,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -875,7 +934,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'checks'            Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -884,7 +944,8 @@
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'success'           Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -920,7 +981,8 @@
 ')'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'success'           Token.Name
@@ -951,12 +1013,14 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bool'              Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'success'           Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'while'             Token.Keyword
 '('                 Token.Punctuation
 '~'                 Token.Operator
@@ -964,12 +1028,14 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'ry'                Token.Name.Function
 '('                 Token.Punctuation
 'pi'                Token.Name.Constant
@@ -981,7 +1047,8 @@
 ' '                 Token.Text.Whitespace
 'magic'             Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'success'           Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -994,7 +1061,8 @@
 'scratch'           Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
 '\n'                Token.Text.Whitespace
 '}'                 Token.Punctuation
@@ -1046,7 +1114,8 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'int'               Token.Keyword.Type
 '['                 Token.Punctuation
 '32'                Token.Literal.Number
@@ -1054,17 +1123,20 @@
 ' '                 Token.Text.Whitespace
 'index'             Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'success_0'         Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'success_1'         Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'let'               Token.Keyword.Declaration
 ' '                 Token.Text.Whitespace
 'magic_lvl0'        Token.Name
@@ -1079,7 +1151,8 @@
 '9'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'let'               Token.Keyword.Declaration
 ' '                 Token.Text.Whitespace
 'magic_lvl1_0'      Token.Name
@@ -1094,7 +1167,8 @@
 '19'                Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'let'               Token.Keyword.Declaration
 ' '                 Token.Text.Whitespace
 'magic_lvl1_1'      Token.Name
@@ -1109,7 +1183,8 @@
 '29'                Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'let'               Token.Keyword.Declaration
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
@@ -1124,11 +1199,14 @@
 '32'                Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Run first-level circuits until 10 successes,' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// storing the outputs for use in the second level' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -1145,7 +1223,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'rus_level_0'       Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic_lvl0'        Token.Name
@@ -1153,7 +1232,8 @@
 ' '                 Token.Text.Whitespace
 'scratch'           Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'swap'              Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic_lvl0'        Token.Name
@@ -1167,7 +1247,8 @@
 'i'                 Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'swap'              Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic_lvl0'        Token.Name
@@ -1181,11 +1262,14 @@
 'i'                 Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Run two second level circuits simultaneously' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'success_0'         Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -1198,7 +1282,8 @@
 'scratch'           Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'success_1'         Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -1211,9 +1296,11 @@
 'scratch'           Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Move usable magic states into the buffer register' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'success_0'         Token.Name
@@ -1228,7 +1315,8 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'swap'              Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic_lvl1_0'      Token.Name
@@ -1252,16 +1340,19 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'index'             Token.Name
 ' '                 Token.Text.Whitespace
 '+='                Token.Operator
 ' '                 Token.Text.Whitespace
 '2'                 Token.Literal.Number
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'success_1'         Token.Name
@@ -1276,7 +1367,8 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'swap'              Token.Name.Function
 ' '                 Token.Text.Whitespace
 'magic_lvl1_1'      Token.Name
@@ -1300,14 +1392,16 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'index'             Token.Name
 ' '                 Token.Text.Whitespace
 '+='                Token.Operator
 ' '                 Token.Text.Whitespace
 '2'                 Token.Literal.Number
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
 '\n'                Token.Text.Whitespace
 '}'                 Token.Punctuation
@@ -1342,12 +1436,14 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'outcome'           Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cy'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'buffer'            Token.Name
@@ -1358,7 +1454,8 @@
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'outcome'           Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -1371,7 +1468,8 @@
 ']'                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'outcome'           Token.Name

--- a/tests/examples/qasm3/qec.qasm.output
+++ b/tests/examples/qasm3/qec.qasm.output
@@ -70,7 +70,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 '['                 Token.Punctuation
 '2'                 Token.Literal.Number
@@ -78,7 +79,8 @@
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'd'                 Token.Name
@@ -92,7 +94,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'd'                 Token.Name
@@ -106,7 +109,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'd'                 Token.Name
@@ -120,7 +124,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'd'                 Token.Name
@@ -134,7 +139,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'measure'           Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'a'                 Token.Name
@@ -143,7 +149,8 @@
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name

--- a/tests/examples/qasm3/rus.qasm.output
+++ b/tests/examples/qasm3/rus.qasm.output
@@ -57,7 +57,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 '['                 Token.Punctuation
 '2'                 Token.Literal.Number
@@ -65,17 +66,20 @@
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'anc'               Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'anc'               Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'ccx'               Token.Name.Function
 ' '                 Token.Text.Whitespace
 'anc'               Token.Name
@@ -92,12 +96,14 @@
 ' '                 Token.Text.Whitespace
 'psi'               Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 's'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'psi'               Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'ccx'               Token.Name.Function
 ' '                 Token.Text.Whitespace
 'anc'               Token.Name
@@ -114,17 +120,20 @@
 ' '                 Token.Text.Whitespace
 'psi'               Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'z'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'psi'               Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'anc'               Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'measure'           Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'anc'               Token.Name
@@ -133,7 +142,8 @@
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
@@ -199,7 +209,8 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'flags'             Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator

--- a/tests/examples/qasm3/scqec.qasm.output
+++ b/tests/examples/qasm3/scqec.qasm.output
@@ -265,9 +265,11 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Hadamards in the bulk' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -289,7 +291,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -311,7 +314,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 '['                 Token.Punctuation
 '32'                Token.Literal.Number
@@ -333,7 +337,8 @@
 'col'               Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'sum'               Token.Name
@@ -345,7 +350,8 @@
 ' '                 Token.Text.Whitespace
 '1'                 Token.Literal.Number
 ')'                 Token.Punctuation
-'\n        '        Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'        '          Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'ancilla'           Token.Name
@@ -367,13 +373,17 @@
 'col'               Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Hadamards on the left and right boundaries' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -397,7 +407,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'ancilla'           Token.Name
@@ -427,7 +438,8 @@
 'i'                 Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
 '\n'                Token.Text.Whitespace
 '}'                 Token.Punctuation
@@ -468,19 +480,23 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'ancilla'           Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'hadamard_layer'    Token.Name.Function
 ' '                 Token.Text.Whitespace
 'ancilla'           Token.Name
 ';'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// First round of CNOTs in the bulk' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -504,7 +520,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -527,7 +544,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 '['                 Token.Punctuation
 '32'                Token.Literal.Number
@@ -549,7 +567,8 @@
 'col'               Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'sum'               Token.Name
@@ -561,7 +580,8 @@
 ' '                 Token.Text.Whitespace
 '0'                 Token.Literal.Number
 ')'                 Token.Punctuation
-'\n        '        Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'        '          Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'data'              Token.Name
@@ -597,7 +617,8 @@
 'col'               Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'sum'               Token.Name
@@ -611,7 +632,8 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n        '        Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'        '          Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'ancilla'           Token.Name
@@ -647,15 +669,20 @@
 'col'               Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// First round of CNOTs on the bottom boundary' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -685,7 +712,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'data'              Token.Name
@@ -745,11 +773,14 @@
 'i'                 Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// First round of CNOTs on the right boundary' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -779,7 +810,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'ancilla'           Token.Name
@@ -845,16 +877,20 @@
 'i'                 Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Remaining rounds of CNOTs, go here ...' Token.Comment.Single
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'hadamard_layer'    Token.Name.Function
 ' '                 Token.Text.Whitespace
 'ancilla'           Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'measure'           Token.Operator.Word
@@ -885,14 +921,17 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Initialize'     Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'data'              Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'layer'             Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -905,7 +944,8 @@
 'ancilla'           Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'zfirst'            Token.Name.Function
 '('                 Token.Punctuation
 'layer'             Token.Name
@@ -917,9 +957,11 @@
 'd'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// m cycles of syndrome measurement' Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'int'               Token.Keyword.Type
@@ -939,7 +981,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'layer'             Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -952,7 +995,8 @@
 'ancilla'           Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'send'              Token.Name.Function
 '('                 Token.Punctuation
 'layer'             Token.Name
@@ -967,11 +1011,14 @@
 'd'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '// Measure'        Token.Comment.Single
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'data_outcomes'     Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -980,7 +1027,8 @@
 ' '                 Token.Text.Whitespace
 'data'              Token.Name
 ';'                 Token.Punctuation
-'\n\n  '            Token.Text.Whitespace
+'\n\n'              Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'outcome'           Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -996,7 +1044,8 @@
 'd'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'failures'          Token.Name
 ' '                 Token.Text.Whitespace
 '+='                Token.Operator

--- a/tests/examples/qasm3/varteleport.qasm.output
+++ b/tests/examples/qasm3/varteleport.qasm.output
@@ -45,12 +45,14 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
@@ -58,7 +60,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
@@ -85,12 +88,14 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
@@ -165,7 +170,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'let'               Token.Keyword.Declaration
 ' '                 Token.Text.Whitespace
 'bp'                Token.Name
@@ -190,7 +196,8 @@
 '}'                 Token.Punctuation
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 '['                 Token.Punctuation
 '2'                 Token.Literal.Number
@@ -198,12 +205,14 @@
 ' '                 Token.Text.Whitespace
 'pf'                Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bellprep'          Token.Name.Function
 ' '                 Token.Text.Whitespace
 'bp'                Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'cx'                Token.Name.Function
 ' '                 Token.Text.Whitespace
 'io'                Token.Name
@@ -214,12 +223,14 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'h'                 Token.Name.Function
 ' '                 Token.Text.Whitespace
 'io'                Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'pf'                Token.Name
 '['                 Token.Punctuation
 '0'                 Token.Literal.Number
@@ -231,7 +242,8 @@
 ' '                 Token.Text.Whitespace
 'io'                Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'pf'                Token.Name
 '['                 Token.Punctuation
 '1'                 Token.Literal.Number
@@ -246,7 +258,8 @@
 '0'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 ' '                 Token.Text.Whitespace
 '('                 Token.Punctuation
@@ -265,7 +278,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'if'                Token.Keyword
 ' '                 Token.Text.Whitespace
 '('                 Token.Punctuation
@@ -284,7 +298,8 @@
 '1'                 Token.Literal.Number
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'let'               Token.Keyword.Declaration
 ' '                 Token.Text.Whitespace
 'io'                Token.Name

--- a/tests/examples/qasm3/vqe.qasm.output
+++ b/tests/examples/qasm3/vqe.qasm.output
@@ -328,7 +328,8 @@
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
@@ -337,7 +338,8 @@
 ' '                 Token.Text.Whitespace
 '0'                 Token.Literal.Number
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -361,12 +363,14 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'temp'              Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'spec'              Token.Name
@@ -404,7 +408,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'spec'              Token.Name
@@ -441,7 +446,8 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'spec'              Token.Name
@@ -479,16 +485,19 @@
 ';'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'b'                 Token.Name
 ' '                 Token.Text.Whitespace
 '^='                Token.Operator
 ' '                 Token.Text.Whitespace
 'temp'              Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
@@ -511,7 +520,8 @@
 ')'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'int'               Token.Keyword.Type
@@ -535,7 +545,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -559,7 +570,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 'angle'             Token.Keyword.Type
 '['                 Token.Punctuation
 'prec'              Token.Name
@@ -567,7 +579,8 @@
 ' '                 Token.Text.Whitespace
 'theta'             Token.Name
 ';'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 'theta'             Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -585,7 +598,8 @@
 'i'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n      '          Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'      '            Token.Text.Whitespace
 'ry'                Token.Name.Function
 '('                 Token.Punctuation
 'theta'             Token.Name
@@ -596,9 +610,11 @@
 'i'                 Token.Name
 ']'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'if'                Token.Keyword
 '('                 Token.Punctuation
 'l'                 Token.Name
@@ -616,7 +632,8 @@
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
 '\n'                Token.Text.Whitespace
 '}'                 Token.Punctuation
@@ -657,7 +674,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 '['                 Token.Punctuation
 'prec'              Token.Name
@@ -665,7 +683,8 @@
 ' '                 Token.Text.Whitespace
 'counts'            Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'uint'              Token.Keyword.Type
@@ -682,22 +701,26 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 ' '                 Token.Text.Whitespace
 'b'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'reset'             Token.Operator.Word
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'trial_circuit'     Token.Name.Function
 ' '                 Token.Text.Whitespace
 'q'                 Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'b'                 Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -710,7 +733,8 @@
 'q'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'counts'            Token.Name
 ' '                 Token.Text.Whitespace
 '+='                Token.Operator
@@ -723,9 +747,11 @@
 'b'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'counts'            Token.Name
@@ -755,7 +781,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'float'             Token.Keyword.Type
 '['                 Token.Punctuation
 'prec'              Token.Name
@@ -763,7 +790,8 @@
 ' '                 Token.Text.Whitespace
 'energy'            Token.Name
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 '['                 Token.Punctuation
 'prec'              Token.Name
@@ -777,7 +805,8 @@
 '('                 Token.Punctuation
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'for'               Token.Keyword
 ' '                 Token.Text.Whitespace
 'int'               Token.Keyword.Type
@@ -798,7 +827,8 @@
 ']'                 Token.Punctuation
 ' '                 Token.Text.Whitespace
 '{'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'bit'               Token.Keyword.Type
 '['                 Token.Punctuation
 '2'                 Token.Literal.Number
@@ -815,7 +845,8 @@
 't'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'uint'              Token.Keyword.Type
 '['                 Token.Punctuation
 'prec'              Token.Name
@@ -823,7 +854,8 @@
 ' '                 Token.Text.Whitespace
 'counts'            Token.Name
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'counts'            Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -836,7 +868,8 @@
 'q'                 Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n    '            Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'    '              Token.Text.Whitespace
 'energy'            Token.Name
 ' '                 Token.Text.Whitespace
 '='                 Token.Operator
@@ -852,9 +885,11 @@
 'energy'            Token.Name
 ')'                 Token.Punctuation
 ';'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 '}'                 Token.Punctuation
-'\n  '              Token.Text.Whitespace
+'\n'                Token.Text.Whitespace
+'  '                Token.Text.Whitespace
 'return'            Token.Keyword
 ' '                 Token.Text.Whitespace
 'energy'            Token.Name

--- a/tests/test_qasm3_lexer.py
+++ b/tests/test_qasm3_lexer.py
@@ -71,17 +71,69 @@ def test_for_loop_variable_not_callable(lexer_qasm3):
 def test_annotation_namespace(lexer_qasm3):
     text = """\
 @annotation
+@annotation payload
 @namespace.annotation
-@namespace1.namespace2.annotation
+@namespace1.namespace2.annotation some payload
 qubit q;
 """
     assert _remove_whitespace(lexer_qasm3.get_tokens(text)) == [
         (token.Name.Decorator, "@annotation"),
+        (token.Name.Decorator, "@annotation"),
+        (token.Text, "payload"),
         (token.Name.Decorator, "@namespace.annotation"),
         (token.Name.Decorator, "@namespace1.namespace2.annotation"),
+        (token.Text, "some payload"),
         (token.Keyword.Type, "qubit"),
         (token.Name, "q"),
         (token.Punctuation, ";"),
+    ]
+
+
+def test_indented_annotation(lexer_qasm3):
+    text = """
+box {
+    @annotation payload
+    @annotation
+
+    @a.b payload
+    box {}
+}
+"""
+    assert _remove_whitespace(lexer_qasm3.get_tokens(text)) == [
+        (token.Keyword, "box"),
+        (token.Punctuation, "{"),
+        (token.Name.Decorator, "@annotation"),
+        (token.Text, "payload"),
+        (token.Name.Decorator, "@annotation"),
+        (token.Name.Decorator, "@a.b"),
+        (token.Text, "payload"),
+        (token.Keyword, "box"),
+        (token.Punctuation, "{"),
+        (token.Punctuation, "}"),
+        (token.Punctuation, "}"),
+    ]
+
+
+def test_indented_pragma(lexer_qasm3):
+    text = """
+pragma payload
+#pragma
+box {
+    #pragma another payload
+
+    pragma
+}
+"""
+    assert _remove_whitespace(lexer_qasm3.get_tokens(text)) == [
+        (token.Comment.Preproc, "pragma"),
+        (token.Text, "payload"),
+        (token.Comment.Preproc, "#pragma"),
+        (token.Keyword, "box"),
+        (token.Punctuation, "{"),
+        (token.Comment.Preproc, "#pragma"),
+        (token.Text, "another payload"),
+        (token.Comment.Preproc, "pragma"),
+        (token.Punctuation, "}"),
     ]
 
 


### PR DESCRIPTION
Pygments offers the `bygroups` helper to split simple context-sensitive tokens (like annotations) up into components based on regex groups, which lets us avoid including leading whitespace in annotation and pragma tokens while remaining newline-sensitive.

The whitespace tokenisation needs to break after runs of newlines to allow the newline-sensitive tokens to detect that they _are_ at the start of a line.

Fix #7