### PR TITLE
fix: lexing of annotations with namespace

### DIFF
--- a/src/openqasm_pygments/qasm3.py
+++ b/src/openqasm_pygments/qasm3.py
@@ -80,7 +80,7 @@ class OpenQASM3Lexer(RegexLexer):
                 "annotation",
             ),
             (
-                r"^([ \t]*)(@\w+(\.\w+)*)([ \t]*)",
+                r"^([ \t]*)(@\w+(?:\.\w+)*)([ \t]*)",
                 bygroups(token.Whitespace, token.Name.Decorator, token.Whitespace),
                 "annotation",
             ),

--- a/tests/examples/qasm3/annotations.qasm
+++ b/tests/examples/qasm3/annotations.qasm
@@ -1,0 +1,9 @@
+// Test lexing of annotations with namespaces
+OPENQASM 3.1;
+@annotation
+@annotation value
+@annotation.long.namespace
+@annotation.long.namespace  value
+ @annotation.long.namespace
+ @annotation.long.namespace  value
+h q;

--- a/tests/examples/qasm3/annotations.qasm.output
+++ b/tests/examples/qasm3/annotations.qasm.output
@@ -1,0 +1,32 @@
+'// Test lexing of annotations with namespaces' Token.Comment.Single
+'\n'                                            Token.Text.Whitespace
+'OPENQASM'                                      Token.Comment.Preproc
+' '                                             Token.Text.Whitespace
+'3.1'                                           Token.Literal
+';'                                             Token.Punctuation
+'\n'                                            Token.Text.Whitespace
+'@annotation'                                   Token.Name.Decorator
+'\n'                                            Token.Text.Whitespace
+'@annotation'                                   Token.Name.Decorator
+' '                                             Token.Text.Whitespace
+'value'                                         Token.Text
+'\n'                                            Token.Text.Whitespace
+'@annotation.long.namespace'                    Token.Name.Decorator
+'\n'                                            Token.Text.Whitespace
+'@annotation.long.namespace'                    Token.Name.Decorator
+'  '                                            Token.Text.Whitespace
+'value'                                         Token.Text
+'\n'                                            Token.Text.Whitespace
+' '                                             Token.Text.Whitespace
+'@annotation.long.namespace'                    Token.Name.Decorator
+'\n'                                            Token.Text.Whitespace
+' '                                             Token.Text.Whitespace
+'@annotation.long.namespace'                    Token.Name.Decorator
+'  '                                            Token.Text.Whitespace
+'value'                                         Token.Text
+'\n'                                            Token.Text.Whitespace
+'h'                                             Token.Name.Function
+' '                                             Token.Text.Whitespace
+'q'                                             Token.Name
+';'                                             Token.Punctuation
+'\n'                                            Token.Text.Whitespace


### PR DESCRIPTION
The old regex had a nested capture-group to match the optional namespace in annotations.
This capture-group was categorized as `Token.Text.Whitespace` and caused incorrect syntax highlighting.

We're now using a [non-capturing group](https://docs.python.org/3/howto/regex.html#non-capturing-and-named-groups) for the namespace part to not treat the nested group as extra token.

---

Fixes #11 